### PR TITLE
Improve code blocks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,4 +19,7 @@ markup:
         mark:
           enable: true
   highlight:
-    style: tango
+    noClasses: false
+    lineNos: false
+    codeFences: true
+    guessSyntax: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,6 +30,9 @@
             mermaid.initialize({ startOnLoad: true });
         </script>
     {{ end }}
+    
+    <!-- Add copy-to-clipboard functionality for code blocks -->
+    <script src="/js/copy-code.js"></script>
 </body>
 
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,6 +7,7 @@
     <title>{{ .Site.Title }}</title>
     <meta name="description" content="{{ .Site.Params.description }}">
     <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/syntax.css">
 </head>
 
 <body>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -250,35 +250,6 @@ audio {
     fill: currentColor;
 }
 
-code,
-textarea {
-    font-family: ui-monospace, SF Mono, Menlo, Monaco, Andale Mono, monospace;
-    font-size: 1em;
-    opacity: .7;
-}
-
-a code {
-    opacity: 1;
-}
-
-/* for code samples */
-pre,
-textarea {
-    font-size: .9em;
-    color: inherit;
-    line-height: 1.6;
-    padding: .6em .9em;
-    margin: .8em 0 1em 0;
-    position: relative;
-    display: block;
-    width: 100%;
-    white-space: pre;
-    border: 0;
-    border-radius: 8px;
-    background: rgba(255, 255, 100, .075);
-    overflow-x: auto; /* Add this line to make the code scrollable */
-}
-
 /* Inline footnotes */
 
 label {

--- a/static/css/syntax.css
+++ b/static/css/syntax.css
@@ -1,0 +1,157 @@
+/* Light mode syntax highlighting */
+:root {
+    --code-background: rgba(245, 245, 245, 0.9);
+    --code-text: #333333;
+    --code-comment: #8e908c;
+    --code-keyword: #8959a8;
+    --code-number: #f5871f;
+    --code-string: #718c00;
+    --code-variable: #c82829;
+    --code-function: #4271ae;
+    --code-operator: #3e999f;
+    --code-punctuation: #767676;
+}
+
+/* Dark mode syntax highlighting */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --code-background: rgba(40, 44, 52, 0.9);
+        --code-text: #abb2bf;
+        --code-comment: #5c6370;
+        --code-keyword: #c678dd;
+        --code-number: #d19a66;
+        --code-string: #98c379;
+        --code-variable: #e06c75;
+        --code-function: #61afef;
+        --code-operator: #56b6c2;
+        --code-punctuation: #abb2bf;
+    }
+}
+
+/* Apply syntax highlighting styles */
+pre,
+code {
+    font-family: ui-monospace, SF Mono, Menlo, Monaco, Andale Mono, monospace;
+}
+
+pre {
+    background-color: var(--code-background);
+    color: var(--code-text);
+    border-radius: 8px;
+    padding: 1em;
+    overflow-x: auto;
+    margin: 1.5em 0;
+}
+
+/* Style inline code differently from code blocks */
+:not(pre)>code:not(a>code) {
+    background-color: var(--code-background);
+    color: var(--code-text);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+}
+
+/* Syntax highlighting specific classes */
+.highlight {
+    background-color: var(--code-background);
+    border-radius: 8px;
+}
+
+.highlight pre {
+    margin: 0;
+    padding: .6em .9em;
+    margin: .8em 0 1em 0;
+    white-space: pre;
+}
+
+/* Specific syntax elements */
+.highlight .c,
+.highlight .ch,
+.highlight .cm,
+.highlight .c1,
+.highlight .cs,
+.highlight .cp,
+.highlight .cpf {
+    color: var(--code-comment);
+    /* Comment */
+}
+
+.highlight .k,
+.highlight .kc,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr,
+.highlight .kt {
+    color: var(--code-keyword);
+    /* Keyword */
+}
+
+.highlight .m,
+.highlight .mb,
+.highlight .mf,
+.highlight .mh,
+.highlight .mi,
+.highlight .mo,
+.highlight .il {
+    color: var(--code-number);
+    /* Number */
+}
+
+.highlight .s,
+.highlight .sa,
+.highlight .sb,
+.highlight .sc,
+.highlight .dl,
+.highlight .sd,
+.highlight .s2,
+.highlight .sh,
+.highlight .si,
+.highlight .sx,
+.highlight .sr,
+.highlight .s1,
+.highlight .ss {
+    color: var(--code-string);
+    /* String */
+}
+
+.highlight .n,
+.highlight .na,
+.highlight .nb,
+.highlight .nc,
+.highlight .no,
+.highlight .nd,
+.highlight .ni,
+.highlight .ne,
+.highlight .nf,
+.highlight .nl,
+.highlight .nn,
+.highlight .nx,
+.highlight .py,
+.highlight .nt,
+.highlight .nv,
+.highlight .vc,
+.highlight .vg,
+.highlight .vi,
+.highlight .vm {
+    color: var(--code-variable);
+    /* Name */
+}
+
+.highlight .o,
+.highlight .ow {
+    color: var(--code-operator);
+    /* Operator */
+}
+
+.highlight .p,
+.highlight .pi {
+    color: var(--code-punctuation);
+    /* Punctuation */
+}
+
+/* Function names */
+.highlight .nf,
+.highlight .fm {
+    color: var(--code-function);
+}

--- a/static/css/syntax.css
+++ b/static/css/syntax.css
@@ -10,6 +10,9 @@
     --code-function: #4271ae;
     --code-operator: #3e999f;
     --code-punctuation: #767676;
+    --copy-button-bg: rgba(255, 255, 255, 0.7);
+    --copy-button-hover: rgba(255, 255, 255, 0.9);
+    --copy-button-text: #666;
 }
 
 /* Dark mode syntax highlighting */
@@ -25,6 +28,9 @@
         --code-function: #61afef;
         --code-operator: #56b6c2;
         --code-punctuation: #abb2bf;
+        --copy-button-bg: rgba(30, 34, 42, 0.7);
+        --copy-button-hover: rgba(30, 34, 42, 0.9);
+        --copy-button-text: #aaa;
     }
 }
 
@@ -55,6 +61,7 @@ pre {
 .highlight {
     background-color: var(--code-background);
     border-radius: 8px;
+    position: relative;
 }
 
 .highlight pre {
@@ -62,6 +69,61 @@ pre {
     padding: .6em .9em;
     margin: .8em 0 1em 0;
     white-space: pre;
+}
+
+/* Copy button styling */
+.copy-button {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+    padding: 0.25em 0.5em;
+    font-size: 0.8em;
+    background: var(--copy-button-bg);
+    border: none;
+    border-radius: 4px;
+    color: var(--copy-button-text);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.3em;
+}
+
+.highlight:hover .copy-button {
+    opacity: 1;
+}
+
+.copy-button:hover {
+    background: var(--copy-button-hover);
+}
+
+/* Copy success message */
+.copy-button.copied::after {
+    content: "Copied!";
+    position: absolute;
+    top: 0;
+    right: 110%;
+    background: var(--copy-button-bg);
+    padding: 0.25em 0.5em;
+    border-radius: 4px;
+    font-size: 0.9em;
+    white-space: nowrap;
+    animation: fade-out 1.5s forwards;
+}
+
+@keyframes fade-out {
+    0% {
+        opacity: 1;
+    }
+
+    70% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+    }
 }
 
 /* Specific syntax elements */

--- a/static/js/copy-code.js
+++ b/static/js/copy-code.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', function() {
+    // SVG for clipboard icon (borrowed from github.com)
+    const clipboardSvg = `
+      <svg aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" display="inline-block" overflow="visible" style="vertical-align:text-bottom">
+        <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
+        <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+      </svg>
+    `;
+  
+    // Find all code blocks
+    const codeBlocks = document.querySelectorAll('.highlight');
+    
+    codeBlocks.forEach(block => {
+      // Create the copy button
+      const button = document.createElement('button');
+      button.className = 'copy-button';
+      button.innerHTML = clipboardSvg + 'Copy';
+      button.type = 'button';
+      
+      // Add the button to the code block
+      block.appendChild(button);
+      
+      // Add click event
+      button.addEventListener('click', async () => {
+        const code = block.querySelector('pre').textContent;
+        
+        try {
+          await navigator.clipboard.writeText(code);
+          button.classList.add('copied');
+          
+          // Remove the class after animation completes
+          setTimeout(() => {
+            button.classList.remove('copied');
+          }, 2000);
+        } catch (err) {
+          console.error('Failed to copy: ', err);
+        }
+      });
+    });
+  });


### PR DESCRIPTION
- add a copy-code button on hover
- add custom syntax highlighting stylesheet with support for dynamic light/dark mode

Improvements:
> [!WARNING]
> I assume that the javascript added for the `copy-code.js` is idiomatic and doesn't increase page bloat/load time etc
- Add a little annotation div to the top of code block that states the language type (can use a `layouts/_default/_markup/render-codeblock.html` hook)
- Ensure that code blocks can be copied on mobile too (require one tap?)

Closes #9

