### PR TITLE
fix(rss): use CDATA, correct namespaces, restrict feed output

### DIFF
--- a/content/library/_index.md
+++ b/content/library/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Library
+outputs:
+  - HTML
 ---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -20,6 +20,14 @@ taxonomies:
 enableGitInfo: true
 minify:
   minifyOutput: true
+  disableXML: true
+
+outputs:
+  home:     ["HTML", "RSS"]
+  section:  ["HTML", "RSS"]
+  taxonomy: ["HTML"]
+  term:     ["HTML"]
+  page:     ["HTML"]
 
 markup:
   goldmark:

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -31,7 +31,7 @@
 {{- $pages = $pages | first $limit }}
 {{- end }}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
@@ -52,8 +52,8 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
-      <content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>
+      <description>{{ printf "<![CDATA[%s]]>" .Summary | safeHTML }}</description>
+      <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
     </item>
     {{- end }}
   </channel>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -52,8 +52,8 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ printf "<![CDATA[%s]]>" .Summary | safeHTML }}</description>
-      <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
+      <description>{{ printf "<![CDATA[%s]]>" (replace (printf "%s" .Summary) "]]>" "]]]]><![CDATA[>") | safeHTML }}</description>
+      <content:encoded>{{ printf "<![CDATA[%s]]>" (replace (printf "%s" .Content) "]]>" "]]]]><![CDATA[>") | safeHTML }}</content:encoded>
     </item>
     {{- end }}
   </channel>

--- a/layouts/home.rss.xml
+++ b/layouts/home.rss.xml
@@ -22,7 +22,7 @@
 {{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
 {{- $pages := slice }}
 {{- if or $.IsHome $.IsSection }}
-{{- $pages = $pctx.RegularPages }}
+{{- $pages = where $pctx.RegularPages "Section" "ne" "library" }}
 {{- else }}
 {{- $pages = $pctx.Pages }}
 {{- end }}
@@ -31,7 +31,7 @@
 {{- $pages = $pages | first $limit }}
 {{- end }}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
@@ -52,8 +52,8 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
-      <content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>
+      <description>{{ printf "<![CDATA[%s]]>" .Summary | safeHTML }}</description>
+      <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
     </item>
     {{- end }}
   </channel>

--- a/layouts/home.rss.xml
+++ b/layouts/home.rss.xml
@@ -52,8 +52,8 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ printf "<![CDATA[%s]]>" .Summary | safeHTML }}</description>
-      <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
+      <description>{{ printf "<![CDATA[%s]]>" (replace (printf "%s" .Summary) "]]>" "]]]]><![CDATA[>") | safeHTML }}</description>
+      <content:encoded>{{ printf "<![CDATA[%s]]>" (replace (printf "%s" .Content) "]]>" "]]]]><![CDATA[>") | safeHTML }}</content:encoded>
     </item>
     {{- end }}
   </channel>


### PR DESCRIPTION
- Replace transform.XMLEscape with CDATA sections so LaTeX math survives unmangled in description and content:encoded
- Add missing xmlns:content namespace declaratio
- Rename section.rss.xml to _default/rss.xml (idiomatic Hugo catch-all)
- Restrict RSS to home and sections; remove taxonomy/term/library feeds
- Exclude library pages from the home feed
- Add disableXML: true to prevent minifier from mangling CDATA